### PR TITLE
feat: add raw record search endpoints

### DIFF
--- a/data-upload-tools/README.md
+++ b/data-upload-tools/README.md
@@ -35,6 +35,10 @@ All endpoints require: `Authorization: Bearer ps_me2w0k3e_x81fsv0yz3k`
 - `POST /api/data/upload` - Upload historical data or scraped data
 - `GET /api/forecasting/rates` - AI rate forecasting
 
+### Raw Records
+- `GET /api/raw-records/search` - Filter records by fields stored in `payload`
+- `POST /api/raw-records/semantic-search` - Semantic search over embeddings
+
 ### Knowledge Base
 - `POST /api/knowledge/store` - Store qualitative insights
 - `GET /api/knowledge/retrieve` - Search stored insights


### PR DESCRIPTION
## Summary
- add semantic search and JSON field filter endpoints for RawRecord
- document new search APIs in README

## Testing
- `npm test` *(fails: Missing script "test")*


------
https://chatgpt.com/codex/tasks/task_b_689673fbc3048331b85676f23ead44a5