### PR TITLE
Use project-relative paths for scraper configs and logs

### DIFF
--- a/data-upload-tools/.gitignore
+++ b/data-upload-tools/.gitignore
@@ -3,6 +3,7 @@ node_modules/
 npm-debug.log*
 yarn-debug.log*
 yarn-error.log*
+package-lock.json
 
 # Production builds
 dist/

--- a/data-upload-tools/README.md
+++ b/data-upload-tools/README.md
@@ -52,6 +52,19 @@ All endpoints require: `Authorization: Bearer ps_me2w0k3e_x81fsv0yz3k`
 - **Every 2 hours** - Social media mentions
 - **Weekly Sunday 2:00 AM** - Full comprehensive scrape
 
+### Configuration & Logs
+
+Configuration files and log output are stored in a project-relative directory.
+By default, this is the folder containing the scraping scripts, but you can
+override it by setting the `PS_DATA_DIR` environment variable.
+
+Files written to this directory include:
+
+- `social-api-keys.json` – social media API credentials
+- `scraper-config.json` – scheduling options
+- `scraper.log` – scheduler log output
+- `social_mentions_*.json` – exported social media mentions
+
 ## 🧠 Custom GPT Integration
 
 1. Upload `pacific-sands-gpt-schema.json` to ChatGPT Actions

--- a/data-upload-tools/scraper-scheduler.py
+++ b/data-upload-tools/scraper-scheduler.py
@@ -8,16 +8,19 @@ import asyncio
 import schedule
 import time
 import logging
+import os
 from datetime import datetime, timedelta
 import json
 from web_scraping_system import PacificSandsScraper
 
+BASE_DIR = os.environ.get("PS_DATA_DIR", os.path.dirname(os.path.abspath(__file__)))
+
 # Configure logging
 logging.basicConfig(
-    level=logging.INFO, 
+    level=logging.INFO,
     format='%(asctime)s - %(levelname)s - %(message)s',
     handlers=[
-        logging.FileHandler('/Users/simeong/data-upload-tools/scraper.log'),
+        logging.FileHandler(os.path.join(BASE_DIR, 'scraper.log')),
         logging.StreamHandler()
     ]
 )
@@ -60,8 +63,9 @@ class ScrapingScheduler:
             }
         }
         
+        config_path = os.path.join(BASE_DIR, 'scraper-config.json')
         try:
-            with open('/Users/simeong/data-upload-tools/scraper-config.json', 'r') as f:
+            with open(config_path, 'r') as f:
                 config = json.load(f)
                 # Merge with defaults for any missing keys
                 for key, value in default_config.items():
@@ -70,7 +74,7 @@ class ScrapingScheduler:
                 return config
         except FileNotFoundError:
             # Save default config
-            with open('/Users/simeong/data-upload-tools/scraper-config.json', 'w') as f:
+            with open(config_path, 'w') as f:
                 json.dump(default_config, f, indent=2)
             return default_config
 

--- a/data-upload-tools/social-media-scraper.py
+++ b/data-upload-tools/social-media-scraper.py
@@ -8,12 +8,15 @@ import asyncio
 import aiohttp
 import json
 import re
+import os
 from datetime import datetime
 from dataclasses import dataclass, asdict
 from typing import List, Dict, Optional
 import logging
 
 logger = logging.getLogger(__name__)
+
+BASE_DIR = os.environ.get("PS_DATA_DIR", os.path.dirname(os.path.abspath(__file__)))
 
 @dataclass
 class SocialMediaMention:
@@ -58,8 +61,9 @@ class SocialMediaScraper:
 
     def load_api_keys(self):
         """Load social media API keys"""
+        config_path = os.path.join(BASE_DIR, 'social-api-keys.json')
         try:
-            with open('/Users/simeong/data-upload-tools/social-api-keys.json', 'r') as f:
+            with open(config_path, 'r') as f:
                 return json.load(f)
         except FileNotFoundError:
             # Create template file
@@ -82,8 +86,8 @@ class SocialMediaScraper:
                     "user_agent": "PacificSandsScraper/1.0"
                 }
             }
-            
-            with open('/Users/simeong/data-upload-tools/social-api-keys.json', 'w') as f:
+
+            with open(config_path, 'w') as f:
                 json.dump(template, f, indent=2)
                 
             logger.info("Created social-api-keys.json template. Please add your API keys.")
@@ -328,7 +332,7 @@ async def main():
         
         # Save to JSON file
         timestamp = datetime.now().strftime('%Y%m%d_%H%M%S')
-        filename = f'/Users/simeong/data-upload-tools/social_mentions_{timestamp}.json'
+        filename = os.path.join(BASE_DIR, f'social_mentions_{timestamp}.json')
         
         with open(filename, 'w') as f:
             json.dump([asdict(mention) for mention in mentions], f, indent=2, default=str)


### PR DESCRIPTION
## Summary
- derive a base directory from `PS_DATA_DIR` or the script location
- write config files, logs, and outputs with `os.path.join`
- document where configuration and log files are stored

## Testing
- `python -m py_compile data-upload-tools/social-media-scraper.py data-upload-tools/scraper-scheduler.py`


------
https://chatgpt.com/codex/tasks/task_b_6896713624e4833198c0d5608a068fc5