### PR TITLE
feat: ingest competitor and sentiment data

### DIFF
--- a/data-upload-tools/api/upload.js
+++ b/data-upload-tools/api/upload.js
@@ -82,6 +82,38 @@ module.exports = async function handler(req, res) {
             });
             uploadedCount = occupancyRecords.length;
 
+        } else if (data_type === 'competitors') {
+            const competitorRecords = records.map(record => ({
+                competitorName: record.competitor_name || record.competitorName || record.name || 'Unknown',
+                roomType: record.room_type || record.roomType || null,
+                rate: parseFloat(record.rate || 0),
+                date: new Date(record.date || record.check_in || new Date()),
+                sourceUrl: record.source_url || record.sourceUrl || record.url || null,
+                scrapedAt: new Date(record.scraped_at || record.scrapedAt || new Date())
+            }));
+
+            await prisma.competitorRate.createMany({
+                data: competitorRecords,
+                skipDuplicates: true
+            });
+            uploadedCount = competitorRecords.length;
+
+        } else if (data_type === 'mentions') {
+            const mentionRecords = records.map(record => ({
+                platform: record.platform || 'unknown',
+                content: record.content || '',
+                author: record.author || null,
+                sentiment: record.sentiment || 'neutral',
+                url: record.url || null,
+                timestamp: new Date(record.timestamp || record.date || new Date())
+            }));
+
+            await prisma.socialMention.createMany({
+                data: mentionRecords,
+                skipDuplicates: true
+            });
+            uploadedCount = mentionRecords.length;
+
         } else {
             // For other data types, store as insights
             await prisma.insight.create({

--- a/data-upload-tools/prisma/schema.prisma
+++ b/data-upload-tools/prisma/schema.prisma
@@ -91,3 +91,29 @@ model InsightUploadLink {
   @@map("insight_upload_links")
   @@unique([insightId, uploadId])
 }
+
+model CompetitorRate {
+  id             String   @id @default(cuid())
+  competitorName String   @map("competitor_name")
+  roomType       String?  @map("room_type")
+  rate           Float
+  date           DateTime
+  sourceUrl      String?  @map("source_url")
+  scrapedAt      DateTime @default(now()) @map("scraped_at")
+  createdAt      DateTime @default(now()) @map("created_at")
+
+  @@map("competitor_rates")
+}
+
+model SocialMention {
+  id        String   @id @default(cuid())
+  platform  String
+  content   String
+  author    String?
+  sentiment String
+  url       String?
+  timestamp DateTime
+  createdAt DateTime @default(now()) @map("created_at")
+
+  @@map("social_mentions")
+}

--- a/data-upload-tools/web-scraping-system.py
+++ b/data-upload-tools/web-scraping-system.py
@@ -17,6 +17,7 @@ from bs4 import BeautifulSoup
 import logging
 from urllib.parse import urljoin, urlparse
 import random
+import os
 
 # Configure logging
 logging.basicConfig(level=logging.INFO, format='%(asctime)s - %(levelname)s - %(message)s')
@@ -374,25 +375,25 @@ class PacificSandsScraper:
 
     async def post_to_mcp(self, endpoint: str, data: Dict):
         """Post data to MCP system"""
-        mcp_base_url = "https://your-mcp-domain.com/api"  # Update with actual URL
-        api_key = "ps_me2w0k3e_x81fsv0yz3k"  # Your API key
-        
+        mcp_base_url = os.environ.get("MCP_BASE_URL", "http://localhost:3000/api")
+        api_key = os.environ.get("PS_API_KEY", "ps_me2w0k3e_x81fsv0yz3k")
+
         headers = {
             'Authorization': f'Bearer {api_key}',
             'Content-Type': 'application/json'
         }
-        
+
         try:
             async with self.session.post(
-                f"{mcp_base_url}{endpoint}", 
-                json=data, 
+                f"{mcp_base_url}{endpoint}",
+                json=data,
                 headers=headers
             ) as response:
                 if response.status == 200:
                     logger.info(f"Successfully uploaded {len(data.get('data', []))} records to MCP")
                 else:
                     logger.error(f"Failed to upload to MCP: {response.status}")
-                    
+
         except Exception as e:
             logger.error(f"Error posting to MCP: {e}")
 


### PR DESCRIPTION
## Summary
- extend Prisma schema with competitor and social mention models
- ingest competitor rates and social mentions via upload API
- expose competitor and sentiment analytics with real data
- send scraper output to API for storage

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_b_6896bf783bd483319c6bab390827b996