### PR TITLE
Resolve Prisma schema merge by adding insight models

### DIFF
--- a/data-upload-tools/prisma/schema.prisma
+++ b/data-upload-tools/prisma/schema.prisma
@@ -59,7 +59,7 @@ model UploadMetadata {
   processingTimeMs Int?     @map("processing_time_ms")
   purpose          String?
   tags             String[] @db.Text
-  links            InsightUploadLink[]
+  links            InsightSubmissionLink[]
 
   @@map("upload_metadata")
 }
@@ -75,12 +75,13 @@ model Insight {
   sourceUrl     String?  @map("source_url")
   createdAt     DateTime @default(now()) @map("created_at")
   updatedAt     DateTime @updatedAt @map("updated_at")
-  relatedUploads InsightUploadLink[]
+  relatedUploads InsightSubmissionLink[]
+  ids            InsightId[]
 
   @@map("insights")
 }
 
-model InsightUploadLink {
+model InsightSubmissionLink {
   id        String   @id @default(cuid())
   insightId String
   uploadId  String
@@ -88,8 +89,19 @@ model InsightUploadLink {
   insight   Insight  @relation(fields: [insightId], references: [id], onDelete: Cascade)
   upload    UploadMetadata @relation(fields: [uploadId], references: [id], onDelete: Cascade)
 
-  @@map("insight_upload_links")
+  @@map("insight_submission_links")
   @@unique([insightId, uploadId])
+}
+
+model InsightId {
+  id        String   @id @default(cuid())
+  insightId String
+  value     String
+  createdAt DateTime @default(now()) @map("created_at")
+  insight   Insight  @relation(fields: [insightId], references: [id], onDelete: Cascade)
+
+  @@map("insight_ids")
+  @@unique([insightId, value])
 }
 
 model CompetitorRate {


### PR DESCRIPTION
## Summary
- replace `InsightUploadLink` with new `InsightSubmissionLink`
- add `InsightId` model and wire it to `Insight`
- update `UploadMetadata` and `Insight` to use the new link model

## Testing
- `npm test` (fails: Missing script: "test")
- `npx prisma validate` (fails: Environment variable not found: PRISMA_DATABASE_URL)


------
https://chatgpt.com/codex/tasks/task_b_68972b9315d88331b10a514bb5ac262d