### PR TITLE
Add Prisma setup and item API route

### DIFF
--- a/frontend/.env
+++ b/frontend/.env
@@ -1,0 +1,1 @@
+DATABASE_URL="file:./dev.db"

--- a/frontend/.gitignore
+++ b/frontend/.gitignore
@@ -14,3 +14,5 @@ npm-debug.log*
 yarn-debug.log*
 yarn-error.log*
 pnpm-debug.log*
+dev.db
+package-lock.json

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -12,13 +12,15 @@
   "dependencies": {
     "next": "latest",
     "react": "latest",
-    "react-dom": "latest"
+    "react-dom": "latest",
+    "@prisma/client": "latest"
   },
   "devDependencies": {
     "typescript": "latest",
     "@types/react": "latest",
     "@types/node": "latest",
     "eslint": "latest",
-    "eslint-config-next": "latest"
+    "eslint-config-next": "latest",
+    "prisma": "latest"
   }
 }

--- a/frontend/pages/api/items.ts
+++ b/frontend/pages/api/items.ts
@@ -1,0 +1,12 @@
+import type { NextApiRequest, NextApiResponse } from 'next';
+import { PrismaClient } from '@prisma/client';
+
+const prisma = new PrismaClient();
+
+export default async function handler(
+  req: NextApiRequest,
+  res: NextApiResponse
+) {
+  const items = await prisma.item.findMany();
+  res.status(200).json(items);
+}

--- a/frontend/prisma/schema.prisma
+++ b/frontend/prisma/schema.prisma
@@ -1,0 +1,16 @@
+// Prisma schema file
+// SQLite provider for local development
+
+generator client {
+  provider = "prisma-client-js"
+}
+
+datasource db {
+  provider = "sqlite"
+  url      = env("DATABASE_URL")
+}
+
+model Item {
+  id   Int    @id @default(autoincrement())
+  name String
+}


### PR DESCRIPTION
## Summary
- add Prisma schema with Item model using SQLite for local development
- expose `/api/items` endpoint that queries items via PrismaClient

## Testing
- `npm install @prisma/client prisma` *(fails: 403 Forbidden - GET https://registry.npmjs.org/@prisma%2fconfig)*
- `npx prisma init` *(fails: 403 Forbidden - GET https://registry.npmjs.org/prisma)*
- `npx prisma migrate dev --name init` *(fails: 403 Forbidden - GET https://registry.npmjs.org/prisma)*
- `npx prisma generate` *(fails: 403 Forbidden - GET https://registry.npmjs.org/prisma)*
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_68973988b06c83318f6d31dad02de6d4