### PR TITLE
feat: persist chat history

### DIFF
--- a/frontend/pages/api/messages.ts
+++ b/frontend/pages/api/messages.ts
@@ -1,0 +1,46 @@
+import type { NextApiRequest, NextApiResponse } from 'next';
+import { PrismaClient } from '@prisma/client';
+
+const prisma = new PrismaClient();
+
+export default async function handler(req: NextApiRequest, res: NextApiResponse) {
+  try {
+    if (req.method === 'POST') {
+      const { sessionId, role, content } = req.body;
+      if (!sessionId || !role || !content) {
+        return res.status(400).json({ error: 'sessionId, role, and content are required' });
+      }
+      const message = await prisma.message.create({
+        data: { sessionId, role, content }
+      });
+      return res.status(200).json(message);
+    }
+
+    if (req.method === 'GET') {
+      const { sessionId, search } = req.query;
+      if (typeof search === 'string') {
+        const results = await prisma.message.findMany({
+          where: {
+            content: { contains: search, mode: 'insensitive' }
+          },
+          orderBy: { createdAt: 'asc' }
+        });
+        return res.status(200).json(results);
+      }
+      if (typeof sessionId === 'string') {
+        const history = await prisma.message.findMany({
+          where: { sessionId },
+          orderBy: { createdAt: 'asc' }
+        });
+        return res.status(200).json(history);
+      }
+      return res.status(400).json({ error: 'sessionId or search query required' });
+    }
+
+    res.setHeader('Allow', ['POST', 'GET']);
+    res.status(405).end(`Method ${req.method} Not Allowed`);
+  } catch (error) {
+    console.error('Error handling request', error);
+    res.status(500).json({ error: 'Internal server error' });
+  }
+}

--- a/frontend/prisma/schema.prisma
+++ b/frontend/prisma/schema.prisma
@@ -14,3 +14,13 @@ model Item {
   id   Int    @id @default(autoincrement())
   name String
 }
+
+model Message {
+  id        Int      @id @default(autoincrement())
+  sessionId String
+  role      String
+  content   String
+  createdAt DateTime @default(now())
+
+  @@index([sessionId])
+}


### PR DESCRIPTION
## Summary
- define `Message` model in Prisma schema for storing chat history
- add `/api/messages` endpoint to save and search conversations

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_6897e9984e2483319605cb21a61ac917